### PR TITLE
Fix inconsistent card height on refresh

### DIFF
--- a/src/app/Components/TestimonialContainer/TestimonialContainer.css
+++ b/src/app/Components/TestimonialContainer/TestimonialContainer.css
@@ -2,7 +2,8 @@
     display: flex !important;
     flex-direction: column;
     justify-content: space-between;
-    height: 700px;
+    height: auto;
+    min-height: 400px;
     padding: 30px 20px;
     box-sizing: border-box;
     background: #ffffff;
@@ -39,9 +40,9 @@
     background: transparent;
     border-radius: 20px;
     padding: 40px;
-    height: auto;
-    min-height: unset;
-    max-height: unset;
+    height: auto !important;
+    min-height: unset !important;
+    max-height: unset !important;
     transition: border-color 0.4s ease-in-out;
 }
 


### PR DESCRIPTION
Root cause: base .testimonial-card had height:700px which loaded first on every render. The .testimonials-section-content override with height:auto applied slightly later — slick measured 700px before the override took effect, causing inconsistent dimensions.

Fix:
- Added !important to height/min-height/max-height in scoped rule so it beats the base 700px from the very first paint
- Changed base rule from height:700px to height:auto + min-height:400px eliminating the timing gap entirely