### PR TITLE
Stats: 2-column grid on desktop, single column on mobile

### DIFF
--- a/src/app/Components/Stats/Stats.css
+++ b/src/app/Components/Stats/Stats.css
@@ -1,12 +1,12 @@
 /* Stats Component Styles */
 @import '../../../styles/shared.css';
 
-/* ── Container — single column, matches Register highlights ── */
+/* ── Container ── */
 .stats-container {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  max-width: 800px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  max-width: 1100px;
   margin: 10vh auto 0;
   padding: 0 4rem;
   position: relative;
@@ -16,11 +16,11 @@
 .stat-card {
   position: relative;
   width: 100%;
-  height: 280px;
+  height: 340px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 32px 32px 28px;
+  padding: 36px 36px 30px;
   box-sizing: border-box;
   border-radius: 18px;
   overflow: hidden;
@@ -39,16 +39,23 @@
   filter: brightness(1.07);
 }
 
-/* ── Card colors (always on, same as Register page) ── */
+/* ── Card colors ── */
 .stat-card.card1 { background-color: #C93102 !important; color: #fff !important; }
 .stat-card.card2 { background-color: #EBEBEB !important; color: #0a0a0a !important; }
 .stat-card.card3 { background-color: #B5DFCE !important; color: #0a0a0a !important; }
 .stat-card.card4 { background-color: #F3E453 !important; color: #0a0a0a !important; }
 
-/* ── Number — Inconsolata, slashed-zero, letter-spacing -8px ── */
+/* Stagger: even cards sit lower, odd card 3 sits higher */
+@media (min-width: 768px) {
+  .stat-card.card2 { margin-top: 50px; }
+  .stat-card.card4 { margin-top: 50px; }
+  .stat-card.card3 { margin-top: -50px; }
+}
+
+/* ── Number — Inconsolata, slashed-zero ── */
 .stat-value {
   font-family: 'Inconsolata', monospace;
-  font-size: 7rem;
+  font-size: 8rem;
   font-weight: 400;
   line-height: 1;
   letter-spacing: -8px;
@@ -58,7 +65,7 @@
 
 .stat-sup {
   font-family: 'Inconsolata', monospace;
-  font-size: 2.5rem;
+  font-size: 3rem;
   font-weight: 400;
   vertical-align: super;
   letter-spacing: 0;
@@ -69,22 +76,43 @@
   align-self: flex-end;
   text-align: right;
   font-family: 'Dirtyline36Daysoftype2022', sans-serif;
-  font-size: 2rem;
+  font-size: 2.2rem;
   font-weight: 100;
   text-transform: lowercase;
   line-height: 0.9;
 }
 
-/* ── Mobile ── */
+/* ── Tablet ── */
+@media screen and (max-width: 1050px) {
+  .stats-container {
+    padding: 0 2rem;
+  }
+
+  .stat-value {
+    font-size: 6rem;
+  }
+
+  .stat-sup {
+    font-size: 2.2rem;
+  }
+
+  .stat-label {
+    font-size: 1.8rem;
+  }
+}
+
+/* ── Mobile — single column ── */
 @media screen and (max-width: 768px) {
   .stats-container {
+    grid-template-columns: 1fr;
     padding: 0 1.5rem;
-    gap: 10px;
+    gap: 12px;
   }
 
   .stat-card {
     height: 220px;
     padding: 24px 24px 20px;
+    margin-top: 0 !important;
   }
 
   .stat-value {
@@ -97,7 +125,7 @@
   }
 
   .stat-label {
-    font-size: 1.4rem;
+    font-size: 1.6rem;
   }
 }
 
@@ -117,6 +145,6 @@
   }
 
   .stat-label {
-    font-size: 1.1rem;
+    font-size: 1.2rem;
   }
 }


### PR DESCRIPTION
Desktop: 2-col grid, 340px cards, 8rem numbers, stagger offsets
  (card2/4 +50px, card3 -50px) — matches original home page rhythm
Mobile (≤768px): single column, 220px cards, margins reset 480px: 180px cards, 3.8rem numbers